### PR TITLE
Force labels to unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,26 @@ profile.html:
 
     {% block breadcrumbs %}
         {{ block.super }}
-        {% breadcrumb user.get_full_name "users.views.profile" user.username %}
+        {% breadcrumb user "users.views.profile" user.username %}
     {% endblock %}
 
 Result:
 
     Home / Users and groups / Users / John Doe
+
+It's also possible to use properties.
+
+profile.html:
+
+    {% extends "users.html" %}
+
+    {% load django_bootstrap_breadcrumbs %}
+
+    {% block breadcrumbs %}
+        {{ block.super }}
+        {% breadcrumb user.email "users.views.profile" user.username %}
+    {% endblock %}
+
+Result:
+
+    Home / Users and groups / Users / john.doe@example.org

--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -47,7 +47,7 @@ def render_breadcrumbs(context):
             url = reverse(viewname=viewname, args=args)
         except NoReverseMatch:
             url = viewname
-        links.append((url, _(label) if label else label))
+        links.append((url, _(unicode(label)) if label else label))
 
     if not links:
         return ''


### PR DESCRIPTION
This would happen anyway, but ugettext doesn't like objects. This makes
it easy to display ORM objects.
