### PR TITLE
Pass 'current_app' when rendering view names

### DIFF
--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -7,7 +7,7 @@
 
 from inspect import ismethod
 
-from django.core.urlresolvers import reverse, NoReverseMatch
+from django.core.urlresolvers import reverse, resolve, NoReverseMatch
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -68,7 +68,13 @@ def render_breadcrumbs(context, *args):
             url = viewname.get_absolute_url()
         else:
             try:
-                url = reverse(viewname=viewname, args=view_args)
+                try:
+                    # 'resolver_match' introduced in Django 1.5
+                    current_app = context['request'].resolver_match.namespace
+                except AttributeError:
+                    resolver_match = resolve(context['request'].path)
+                    current_app = resolver_match.namespace
+                url = reverse(viewname=viewname, args=view_args, current_app=current_app)
             except NoReverseMatch:
                 url = viewname
         links.append((url, _(unicode(label)) if label else label))


### PR DESCRIPTION
Hey,

Currently the breadcrumbs don't utilize `current_app` when reversing view names. This can lead to unexpected results when using namespaced URLs.

With this commit, `current_app` is figured out from the request object and passed to `reverse`.

Tested and works on Django 1.5. I didn't have a pre-1.5 codebase handy, but that AttributeError exception handler should cover them. Feel free to test/tweak as needed.

Thanks.
