### PR TITLE
Add a setting for selecting the template in settings.py globally

### DIFF
--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -18,7 +18,7 @@ from django.utils.encoding import smart_text
 from django.utils.translation import ugettext as _
 from django.db.models import Model
 from django import template
-
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +98,8 @@ def render_breadcrumbs(context, *args):
 
     if args:
         template_path = args[0]
+    elif settings.BREADCRUMB_TEMPLATE:
+        template_path = settings.BREADCRUMB_TEMPLATE
     else:
         template_path = 'django_bootstrap_breadcrumbs/bootstrap2.html'
 


### PR DESCRIPTION
Making sure we always use the same rendering template, even if it is
different from the default one. I propose this because I will use render_breadcrumbs in several templates, with Bootstrap 3, and it will be pity to always repeat the path to the V3 template everywhere :)

I did not do any change in the tests, or in the doc. If you merge this pull request, would you like me to check that too ?

Thanks for a great django addon :)