### PR TITLE
give context to render_breadcrumbs template

### DIFF
--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -131,10 +131,11 @@ def render_breadcrumbs(context, *args):
 
     if not links:
         return ''
-
+    context['breadcrumbs'] = links
+    context['breadcrumbs_total'] = len(links)
     return mark_safe(template.loader.render_to_string(
-        template_path, {'breadcrumbs': links,
-                        'breadcrumbs_total': len(links)}))
+        template_path, context))
+
 
 
 class BreadcrumbNode(template.Node):

--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -137,7 +137,6 @@ def render_breadcrumbs(context, *args):
         template_path, context))
 
 
-
 class BreadcrumbNode(template.Node):
 
     def __init__(self, nodelist, viewname, args):


### PR DESCRIPTION
allow us to access to request processors values in the render_breadcrumbs template