### PR TITLE
Add Bootstrap v4 support.

### DIFF
--- a/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap4.html
+++ b/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap4.html
@@ -1,0 +1,9 @@
+<nav class="breadcrumb">
+  {% for url, label in breadcrumbs %}
+    {% ifequal forloop.counter breadcrumbs_total %}
+      <span class="breadcrumb-item active">{{ label|safe }}</span>
+    {% else %}
+      <a class="breadcrumb-item" href="{{ url }}">{{ label|safe }}</a>
+    {% endifequal %}
+  {% endfor %}
+</nav>


### PR DESCRIPTION
Add suport for Bootstrap v4.

Note that [the documentation](http://v4-alpha.getbootstrap.com/components/breadcrumb/) is a little out of date and the use of a list is no longer supported (as can be seen in the [`scss source file`](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_breadcrumb.scss)).