### PR TITLE
Support for empty URL; minor cleanup; more tests

### DIFF
--- a/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap2.html
+++ b/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap2.html
@@ -1,11 +1,11 @@
 <ul class="breadcrumb">
     {% for url, label in breadcrumbs %}
         <li>
-            {% ifnotequal forloop.counter breadcrumbs_total %}
+            {% if url and forloop.counter != breadcrumbs_total %}
                 <a href="{{ url }}">{{ label|safe }}</a>
             {% else %}
                 {{ label|safe }}
-            {% endifnotequal %}
+            {% endif %}
             {% if not forloop.last %}
                 <span class="divider">/</span>
             {% endif %}

--- a/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap3.html
+++ b/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap3.html
@@ -1,11 +1,11 @@
 <ul class="breadcrumb">
     {% for url, label in breadcrumbs %}
         <li{% ifequal forloop.counter breadcrumbs_total %} class="active"{% endifequal %}>
-            {% ifnotequal forloop.counter breadcrumbs_total %}
+            {% if url and forloop.counter != breadcrumbs_total %}
                 <a href="{{ url }}">{{ label|safe }}</a>
             {% else %}
                 {{ label|safe }}
-            {% endifnotequal %}
+            {% endif %}
         </li>
     {% endfor %}
 </ul>

--- a/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap4.html
+++ b/django_bootstrap_breadcrumbs/templates/django_bootstrap_breadcrumbs/bootstrap4.html
@@ -1,9 +1,9 @@
 <nav class="breadcrumb">
   {% for url, label in breadcrumbs %}
-    {% ifequal forloop.counter breadcrumbs_total %}
-      <span class="breadcrumb-item active">{{ label|safe }}</span>
+    {% if not url or forloop.counter == breadcrumbs_total %}
+      <span class="breadcrumb-item{% if forloop.counter == breadcrumbs_total %} active{% endif %}">{{ label|safe }}</span>
     {% else %}
       <a class="breadcrumb-item" href="{{ url }}">{{ label|safe }}</a>
-    {% endifequal %}
+    {% endif %}
   {% endfor %}
 </nav>

--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -31,11 +31,11 @@ CONTEXT_KEY = 'DJANGO_BREADCRUMB_LINKS'
 
 def log_request_not_found():
     from django import VERSION
-    if VERSION < (1, 8):
+    if VERSION < (1, 8):  # pragma: nocover
         logger.error("request object not found in context! Check if "
                      "'django.core.context_processors.request' is in "
                      "TEMPLATE_CONTEXT_PROCESSORS")
-    else:
+    else:  # pragma: nocover
         logger.error("request object not found in context! Check if "
                      "'django.template.context_processors.request' is in the "
                      "'context_processors' option of your template settings.")

--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -19,7 +19,7 @@ from django.utils.translation import ugettext as _
 from django.db.models import Model
 from django.conf import settings
 from django import template
-
+from six import wraps
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +29,34 @@ register = template.Library()
 CONTEXT_KEY = 'DJANGO_BREADCRUMB_LINKS'
 
 
-def append_breadcrumb(context, label, viewname, args, kwargs):
-    if 'request' in context:
-        context['request'].META[CONTEXT_KEY] = context['request'].META.get(
-            CONTEXT_KEY, []) + [(label, viewname, args, kwargs)]
-    else:
+def log_request_not_found():
+    from django import VERSION
+    if VERSION < (1, 8):
         logger.error("request object not found in context! Check if "
                      "'django.core.context_processors.request' is in "
                      "TEMPLATE_CONTEXT_PROCESSORS")
+    else:
+        logger.error("request object not found in context! Check if "
+                     "'django.template.context_processors.request' is in the "
+                     "'context_processors' option of your template settings.")
+
+
+def requires_request(func):
+    @wraps(func)
+    def wrapped(context, *args, **kwargs):
+        if 'request' in context:
+            return func(context, *args, **kwargs)
+
+        log_request_not_found()
+        return ''
+
+    return wrapped
+
+
+@requires_request
+def append_breadcrumb(context, label, viewname, args, kwargs):
+    context['request'].META[CONTEXT_KEY] = context['request'].META.get(
+        CONTEXT_KEY, []) + [(label, viewname, args, kwargs)]
 
 
 @register.simple_tag(takes_context=True)
@@ -87,15 +107,11 @@ def breadcrumb_raw_safe(context, label, viewname, *args, **kwargs):
 
 
 @register.simple_tag(takes_context=True)
+@requires_request
 def render_breadcrumbs(context, *args):
     """
     Render breadcrumbs html using bootstrap css classes.
     """
-    if 'request' not in context:
-        logger.error("request object not found in context! Check if "
-                     "'django.core.context_processors.request' is in "
-                     "TEMPLATE_CONTEXT_PROCESSORS")
-        return ''
 
     if args:
         template_path = args[0]
@@ -153,9 +169,7 @@ class BreadcrumbNode(template.Node):
 
     def render(self, context):
         if 'request' not in context:
-            logger.error("request object not found in context! Check if "
-                         "'django.core.context_processors.request' is in "
-                         "TEMPLATE_CONTEXT_PROCESSORS")
+            log_request_not_found()
             return ''
         label = self.nodelist.render(context)
         try:
@@ -198,15 +212,11 @@ def breadcrumb_for(parser, token):
 
 
 @register.simple_tag(takes_context=True)
+@requires_request
 def clear_breadcrumbs(context, *args):
     """
     Removes all currently added breadcrumbs.
     """
-    if 'request' not in context:
-        logger.error("request object not found in context! Check if "
-                     "'django.core.context_processors.request' is in "
-                     "TEMPLATE_CONTEXT_PROCESSORS")
-        return ''
 
     if CONTEXT_KEY in context['request'].META:
         del context['request'].META[CONTEXT_KEY]

--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -113,13 +113,11 @@ def render_breadcrumbs(context, *args):
     Render breadcrumbs html using bootstrap css classes.
     """
 
-    if args:
+    try:
         template_path = args[0]
-    else:
-        try:
-            template_path = settings.BREADCRUMBS_TEMPLATE
-        except AttributeError:
-            template_path = 'django_bootstrap_breadcrumbs/bootstrap2.html'
+    except IndexError:
+        template_path = getattr(settings, 'BREADCRUMBS_TEMPLATE',
+                                'django_bootstrap_breadcrumbs/bootstrap2.html')
 
     links = []
     for (label, viewname, view_args, view_kwargs) in context[
@@ -218,7 +216,5 @@ def clear_breadcrumbs(context, *args):
     Removes all currently added breadcrumbs.
     """
 
-    if CONTEXT_KEY in context['request'].META:
-        del context['request'].META[CONTEXT_KEY]
-
+    context['request'].META.pop(CONTEXT_KEY, None)
     return ''

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -314,3 +314,4 @@ Contributors:
 * Guillaume DE BURE (gdebure)
 * JeLoueMonCampingCar
 * JP-Ellis
+* Alexandre Macabies (zopieux)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Requirements
 
 * Python >=2.6 (>=3.0 supported since 0.6.1, requires Django >=1.5)
 * Django >= 1.4
-* Bootstrap 2.3 or 3.0
+* Bootstrap 2.3, 3 or 4
 
 Installation
 ============
@@ -43,7 +43,7 @@ After that make necessary changes to Django settings::
 Declaring breadcrumbs
 =====================
 
-There are currently three tags for adding breadcrumbs for pages (remeber to use the tags inside a ``{% block %}``):
+There are currently three tags for adding breadcrumbs for pages (remember to use the tags inside a ``{% block %}``):
 
 ``{% breadcrumb %}``
 ~~~~~~~~~~~~~~~~~~~~
@@ -102,7 +102,7 @@ Example::
 By default breadcrumbs labels are translated using gettext, if the translation should be skipped ``{% breadcrumb_raw %}`` can be used (the label is still escaped). Available since 0.7.0 release.
 
 ``{% breadcrumb_raw_safe %}``
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the label should neither be escaped nor translated ``{% breadcrumb_raw_safe %}`` can be used. Available since 0.7.0 release.
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest==2.9.1
 pytest-pep8==1.0.6
 coverage==4.0.3
 python-coveralls==2.7.0
+testfixtures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django>=1.4
+six

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ setup(
     author='Łukasz Mierzwa',
     author_email='l.mierzwa@gmail.com',
     packages=find_packages(exclude=['tests']),
+    install_requires=[
+        'six',
+    ],
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version='0.7.3',
     url='http://prymitive.github.com/bootstrap-breadcrumbs',
     license='MIT',
-    description='Django breadcrumbs using Bootstrap V2 or V3',
+    description='Django breadcrumbs for Bootstrap 2, 3 or 4',
     long_description='Django template tags used to generate breadcrumbs html '
                      'using bootstrap css classes or custom template',
     author='Łukasz Mierzwa',
@@ -25,7 +25,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Intended Audience :: Developers',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -164,7 +164,7 @@ T_BLOCK_EMPTY_URL = '''
 {% endblock %}
 '''
 
-T_BLOCK_RENDER = '''
+T_BLOCK_RENDER_BS2 = '''
 {% block content %}
 <div>{% render_breadcrumbs %}</div>
 {% endblock %}
@@ -265,7 +265,7 @@ class SiteTests(TestCase):
         self.assertEqual(t.render(self.context), '\n\n\n\n')
 
     def test_render_empty_url_bs2(self):
-        t = Template(T_LOAD + T_BLOCK_EMPTY_URL + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_EMPTY_URL + T_BLOCK_RENDER_BS2)
         self.assertHTMLEqual(t.render(self.context),
                              '<div><ul class="breadcrumb">'
                              '<li>Home For<span class="divider">/</span></li>'
@@ -288,8 +288,8 @@ class SiteTests(TestCase):
                              '<span class="breadcrumb-item active">Home</span>'
                              '</nav></div>')
 
-    def test_render_empty_breadcrumbs(self):
-        t = Template(T_LOAD + T_BLOCK_RENDER)
+    def test_render_empty_breadcrumbs_bs2(self):
+        t = Template(T_LOAD + T_BLOCK_RENDER_BS2)
         self.assertEqual(t.render(self.context), '\n\n<div></div>\n\n')
 
     def test_render_empty_breadcrumbs_bs3(self):
@@ -301,13 +301,13 @@ class SiteTests(TestCase):
         self.assertEqual(t.render(self.context), '\n\n<div>\n\n</div>\n\n')
 
     def test_render_without_request(self):
-        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER_BS2)
         with LogCapture() as log:
             self.assertNotEqual(t.render(Context()), '')
         self.assertRequestError(log)
 
     def test_render(self):
-        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/">&lt;</a>' in resp)
         self.assertTrue('<a href="/login">Login</a>' in resp)
@@ -318,7 +318,7 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 5)
 
     def test_render_safe(self):
-        t = Template(T_LOAD + T_BLOCK_SAFE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_SAFE + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/"><&></a>' in resp)
         self.assertTrue('<span><></span>' in resp)
@@ -353,7 +353,7 @@ class SiteTests(TestCase):
     @override_settings(
         BREADCRUMBS_TEMPLATE='django_bootstrap_breadcrumbs/bootstrap3.html')
     def test_render_bs3_using_settings(self):
-        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/">&lt;</a>' in resp)
         self.assertTrue('<a href="/login">Login</a>' in resp)
@@ -366,7 +366,7 @@ class SiteTests(TestCase):
     @override_settings(
         BREADCRUMBS_TEMPLATE='django_bootstrap_breadcrumbs/bootstrap4.html')
     def test_render_bs4_using_settings(self):
-        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_USER_SAFE + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a class="breadcrumb-item" href="/">&lt;</a>' in resp)
         self.assertTrue('<a class="breadcrumb-item" href="/login">'
@@ -380,7 +380,7 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 5)
 
     def test_render_breadcrumb_for(self):
-        t = Template(T_LOAD + T_BLOCK_FOR + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_FOR + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/static"><span>Static</span></a>' in resp)
         self.assertTrue('Actor' in resp)
@@ -388,7 +388,7 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 2)
 
     def test_render_breadcrumb_for_variable(self):
-        t = Template(T_LOAD + T_BLOCK_FOR_VAR + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_FOR_VAR + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="nonexisting">404</a>' in resp)
         self.assertTrue('<a href="/login/Actor">Login Act</a>' in resp)
@@ -396,27 +396,27 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 4)
 
     def test_render_breadcrumb_kwargs(self):
-        t = Template(T_LOAD + T_BLOCK_KWARGS + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_KWARGS + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/login/user/12345">User 12345</a>' in resp)
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 2)
 
     def test_render_breadcrumb_for_kwargs(self):
-        t = Template(T_LOAD + T_BLOCK_FOR_KWARGS + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_FOR_KWARGS + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/login/user/dummyarg">KV</a>' in resp)
         self.assertTrue('<a href="/login/user/Actor"></a>' in resp)
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 3)
 
     def test_render_breadcrumb_kwargs_model(self):
-        t = Template(T_LOAD + T_BLOCK_KWARGS_MODEL + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_KWARGS_MODEL + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/actor">Actor object</a>' in resp)
         self.assertTrue('<a href="/actor/12345">Actor object</a>' in resp)
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 3)
 
     def test_render_breadcrumb_for_kwargs_model(self):
-        t = Template(T_LOAD + T_BLOCK_FOR_KWARGS_MODEL + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_FOR_KWARGS_MODEL + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/actor">actor</a>' in resp)
         self.assertTrue('<a href="/actor/Actor">actor</a>' in resp)
@@ -425,7 +425,7 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 4)
 
     def test_render_ns(self):
-        t = Template(T_LOAD + T_BLOCK_NS + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_NS + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/ns/login2">Login2</a>' in resp)
         self.assertTrue('<span class="divider">/</span>' in resp)
@@ -433,14 +433,14 @@ class SiteTests(TestCase):
 
     def test_render_ns_app(self):
         self.context['request'].path = '/login'
-        t = Template(T_LOAD + T_BLOCK_NS + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_NS + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/ns/login2">Login2</a>' in resp)
         self.assertTrue('<span class="divider">/</span>' in resp)
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 2)
 
     def test_render_ns_breadcrumb_for(self):
-        t = Template(T_LOAD + T_BLOCK_NS_FOR + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_NS_FOR + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/static"><span>Static</span></a>' in resp)
         self.assertTrue('<a href="/ns/login2">Login2</a>' in resp)
@@ -448,7 +448,7 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 3)
 
     def test_render_ns_breadcrumb_for_quotes(self):
-        t = Template(T_LOAD + T_BLOCK_NS_FOR_QUOTES + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_NS_FOR_QUOTES + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('<a href="/ns/login2">Login2a</a>' in resp)
         self.assertTrue('<a href="/ns/login2">Login2b</a>' in resp)
@@ -456,13 +456,13 @@ class SiteTests(TestCase):
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 3)
 
     def test_render_escape(self):
-        t = Template(T_LOAD + T_BLOCK_ESCAPE + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_ESCAPE + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertTrue('&lt;span&gt;John&lt;/span&gt;' in resp)
         self.assertEqual(len(self.request.META['DJANGO_BREADCRUMB_LINKS']), 2)
 
     def test_render_cleared(self):
-        t = Template(T_LOAD + T_BLOCK_USER_SAFE_CLEAR + T_BLOCK_RENDER)
+        t = Template(T_LOAD + T_BLOCK_USER_SAFE_CLEAR + T_BLOCK_RENDER_BS2)
         resp = t.render(self.context)
         self.assertFalse('<a href="/">Home</a>' in resp)
         self.assertFalse('<a href="/login">Login</a>' in resp)

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -157,6 +157,13 @@ T_BLOCK_FOR_KWARGS_MODEL = '''
 {% endblock %}
 '''
 
+T_BLOCK_EMPTY_URL = '''
+{% block breadcrumbs %}
+{% breadcrumb_for "" %}Home For{% endbreadcrumb_for %}
+{% breadcrumb "Home" "" %}
+{% endblock %}
+'''
+
 T_BLOCK_RENDER = '''
 {% block content %}
 <div>{% render_breadcrumbs %}</div>
@@ -256,6 +263,30 @@ class SiteTests(TestCase):
     def test_push_breadcrumbs_raw_safe(self):
         t = Template(T_LOAD + T_BLOCK_RAW_SAFE)
         self.assertEqual(t.render(self.context), '\n\n\n\n')
+
+    def test_render_empty_url_bs2(self):
+        t = Template(T_LOAD + T_BLOCK_EMPTY_URL + T_BLOCK_RENDER)
+        self.assertHTMLEqual(t.render(self.context),
+                             '<div><ul class="breadcrumb">'
+                             '<li>Home For<span class="divider">/</span></li>'
+                             '<li>Home</li>'
+                             '</ul></div>')
+
+    def test_render_empty_url_bs3(self):
+        t = Template(T_LOAD + T_BLOCK_EMPTY_URL + T_BLOCK_RENDER_BS3)
+        self.assertHTMLEqual(t.render(self.context),
+                             '<div><ul class="breadcrumb">'
+                             '<li>Home For</li>'
+                             '<li class="active">Home</li>'
+                             '</ul></div>')
+
+    def test_render_empty_url_bs4(self):
+        t = Template(T_LOAD + T_BLOCK_EMPTY_URL + T_BLOCK_RENDER_BS4)
+        self.assertHTMLEqual(t.render(self.context),
+                             '<div><nav class="breadcrumb">'
+                             '<span class="breadcrumb-item">Home For</span>'
+                             '<span class="breadcrumb-item active">Home</span>'
+                             '</nav></div>')
 
     def test_render_empty_breadcrumbs(self):
         t = Template(T_LOAD + T_BLOCK_RENDER)


### PR DESCRIPTION
This PR adds support for empty URLs without breaking any existing test and keeping coverage at 100%.

I did **not** update the package version. Please do it if you merge this PR and feel it's needed.

---

List of other minor things done:

- refactor the *request not found* log error and add a better wording for Django ≥ 1.8 (seems to address #20 at least partially)
- minor *pythonicity* improvements
- some typos in the docs/setup.py (eg. support for Bootstrap 4)