### PR TITLE
Django 1.9 template render warning fix

### DIFF
--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -145,8 +145,10 @@ def render_breadcrumbs(context, *args):
 
     if not links:
         return ''
-    context['breadcrumbs'] = links
-    context['breadcrumbs_total'] = len(links)
+    context = {
+        'breadcrumbs': links,
+        'breadcrumbs_total': len(links),
+    }
     return mark_safe(template.loader.render_to_string(
         template_path, context))
 


### PR DESCRIPTION
This PR fixes a Django 1.9 warning when rendering template using a RequestContext instead of a dict.
As per the [deprecation plan](https://docs.djangoproject.com/en/1.9/_modules/django/template/backends/django/|deprecation plan) since 1.8, it is recommanded to send a dictionnary `context` instead of a `Context` or `RequestContext` object when rendering templates. A warning is raised on Django 1.9, but it won't (immediately) break on Django 1.10 thus making a future error silent.

Tested with Django 1.5 to 1.10.