### PR TITLE
FIX: smart_text is deprecated; use smart_str. (Django deprecation)

### DIFF
--- a/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
+++ b/django_bootstrap_breadcrumbs/templatetags/django_bootstrap_breadcrumbs.py
@@ -12,7 +12,7 @@ from inspect import ismethod
 
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.db.models import Model
 from django.conf import settings
 from django import template, VERSION
@@ -148,7 +148,7 @@ def render_breadcrumbs(context, *args):
                               kwargs=view_kwargs, current_app=current_app)
             except NoReverseMatch:
                 url = viewname
-        links.append((url, smart_text(label) if label else label))
+        links.append((url, smart_str(label) if label else label))
 
     if not links:
         return ''


### PR DESCRIPTION
Fixes https://github.com/prymitive/bootstrap-breadcrumbs/issues/64

My test suite has started throwing deprecation warnings about this being fully removed in Django 4.0.

`smart_str()` can be viewed here:
https://github.com/django/django/blob/master/django/utils/encoding.py#L19